### PR TITLE
Upgrade support lib, Kotlin and move kotlin-stdlib to JDK8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,10 +11,10 @@ ext {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -34,7 +34,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:26.0.0-beta1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,11 +25,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:26.0.0-beta1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'

--- a/app/src/main/java/com/poovam/pinedittextfield/LinePinField.kt
+++ b/app/src/main/java/com/poovam/pinedittextfield/LinePinField.kt
@@ -53,7 +53,7 @@ class LinePinField : PinField {
             val textX = ((paddedX2-paddedX1)/2)+paddedX1
             val textY = (paddedY1- lineThickness)-(textPaint.textSize/4)-bottomTextPaddingDp
             hintY = textY
-            val character:Char? = transformationMethod?.getTransformation(text,this)?.getOrNull(i) ?: text.getOrNull(i)
+            val character:Char? = transformationMethod?.getTransformation(text,this)?.getOrNull(i) ?: text?.getOrNull(i)
 
             if(highlightAllFields() && hasFocus()){
                 canvas?.drawLine(paddedX1,paddedY1,paddedX2,paddedY1, highlightPaint)

--- a/app/src/main/java/com/poovam/pinedittextfield/SquarePinField.kt
+++ b/app/src/main/java/com/poovam/pinedittextfield/SquarePinField.kt
@@ -54,7 +54,7 @@ class SquarePinField : PinField{
             val paddedY2 = (height/2)+(squareHeight/2)
             val textX = ((paddedX2-paddedX1)/2)+paddedX1
             val textY = ((paddedY2-paddedY1)/2+paddedY1)+ lineThickness +(textPaint.textSize/4)
-            val character:Char? = transformationMethod?.getTransformation(text,this)?.getOrNull(i) ?: text.getOrNull(i)
+            val character:Char? = transformationMethod?.getTransformation(text,this)?.getOrNull(i) ?: text?.getOrNull(i)
 
             if(highlightAllFields() && hasFocus()){
                 drawRect(canvas,paddedX1,paddedY1,paddedX2,paddedY2, highlightPaint)

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.10'
+    ext.kotlin_version = '1.3.31'
+
     repositories {
         maven { url 'https://maven.google.com' }
         jcenter()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 03 16:15:59 IST 2018
+#Wed Jun 19 18:53:04 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,20 +1,18 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+
 android {
-    compileSdkVersion 26
-
-
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.poovam.sample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
     }
 
     buildTypes {
@@ -31,10 +29,12 @@ android {
 }
 
 dependencies {
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    compile 'com.poovam:pin-edittext-field:1.2.0'
+
+    api 'com.poovam:pin-edittext-field:1.2.0'
     //compile project(':app') //for library development purpose please ignore this line
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,11 +24,15 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
This PR updates the following

- Kotlin to 1.3.31
- kotlin-stdlib from jre7 to jdk8
- Support lib to 28
- sample project to move from compile to api
